### PR TITLE
Remove Paint3D from context menus

### DIFF
--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -748,6 +748,29 @@ $Bloatware = @(
     If (Test-Path $Edge) {
         Set-Item $Edge AppXd4nrz8ff68srnhf9t5a8sbjyar1cr723_ 
     }
+    
+    #Removes Paint3D stuff from context menu
+$Paint3Dstuff = @(
+        "HKCR:\SystemFileAssociations\.3mf\Shell\3D Edit"
+	"HKCR:\SystemFileAssociations\.bmp\Shell\3D Edit"
+	"HKCR:\SystemFileAssociations\.fbx\Shell\3D Edit"
+	"HKCR:\SystemFileAssociations\.gif\Shell\3D Edit"
+	"HKCR:\SystemFileAssociations\.jfif\Shell\3D Edit"
+	"HKCR:\SystemFileAssociations\.jpe\Shell\3D Edit"
+	"HKCR:\SystemFileAssociations\.jpeg\Shell\3D Edit"
+	"HKCR:\SystemFileAssociations\.jpg\Shell\3D Edit"
+	"HKCR:\SystemFileAssociations\.png\Shell\3D Edit"
+	"HKCR:\SystemFileAssociations\.tif\Shell\3D Edit"
+	"HKCR:\SystemFileAssociations\.tiff\Shell\3D Edit"
+    )
+    #Rename reg key to remove it, so it's revertible
+    foreach ($Paint3D in $Paint3Dstuff) {
+        If (Test-Path $Paint3D) {
+	    $rmPaint3D = $Paint3D + "_"
+	    Set-Item $Paint3D $rmPaint3D
+	}
+    }
+    
 	$wshell.Popup("Operation Completed",0,"Done",0x0)
 })
 


### PR DESCRIPTION
When you uninstall Paint3D, the option to open files in Paint3D still stays in your context menus.

![image](https://user-images.githubusercontent.com/20626602/101703739-7ef45280-3a83-11eb-941b-1d94583e8aa1.png)

If you click on it you get sent to install Paint3D via MS Store.

![image](https://user-images.githubusercontent.com/20626602/101703762-8a477e00-3a83-11eb-83bb-804369507523.png)

This script removes this option from context menus via attaching a underscore to the names of registry keys, so it's revertible.