### PR TITLE
Added back OOSU10 config download line

### DIFF
--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -501,6 +501,8 @@ $essentialtweaks.Add_Click({
     Checkpoint-Computer -Description "RestorePoint1" -RestorePointType "MODIFY_SETTINGS"
 
     Write-Host "Running O&O Shutup with Recommended Settings"
+    	Import-Module BitsTransfer
+	Start-BitsTransfer -Source "https://raw.githubusercontent.com/ChrisTitusTech/win10script/master/ooshutup10.cfg" -Destination ooshutup10.cfg
 	choco install shutup10 -y
 	OOSU10 ooshutup10.cfg /quiet
 


### PR DESCRIPTION
I made a mistake by removing the line for downloading the OOSU10 configuration from the repo in #58 . Added it back in this commit.