### PR TITLE
Added new app to uninstall list

### DIFF
--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -1438,6 +1438,7 @@ $Bloatware = @(
     "*Hulu*"
     "*HiddenCity*"
     "*AdobePhotoshopExpress*"
+    "*HotspotShieldFreeVPN*"
 
     #Optional: Typically not removed but you can if you need to for some reason
     "*Microsoft.Advertising.Xaml*"


### PR DESCRIPTION
Added new unwanted app to the uninstall list. Hotspot Shield VPN. 

Found this app left out after running the script on Windows 10 VM running version 2009.

![image](https://user-images.githubusercontent.com/54621884/145210397-058b638d-1458-4f01-a747-35adc08b11a1.png)
