### PR TITLE
Batch Installer for WinGet

### DIFF
--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -293,7 +293,7 @@ $Label4.location                 = New-Object System.Drawing.Point(482,12)
 $Label4.Font                     = New-Object System.Drawing.Font('Microsoft Sans Serif',24)
 
 $Panel3                          = New-Object system.Windows.Forms.Panel
-$Panel3.height                   = 327
+$Panel3.height                   = 363
 $Panel3.width                    = 220
 $Panel3.location                 = New-Object System.Drawing.Point(464,54)
 
@@ -465,7 +465,7 @@ $advancedipscanner.location      = New-Object System.Drawing.Point(3,335)
 $advancedipscanner.Font          = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
 $putty                           = New-Object system.Windows.Forms.Button
-$putty.text                      = "PuTTY & WinSCP"
+$putty.text                      = "PuTTY + WinSCP"
 $putty.width                     = 211
 $putty.height                    = 30
 $putty.location                  = New-Object System.Drawing.Point(3,302)
@@ -539,7 +539,7 @@ $Label10.text                    = "Current Status:"
 $Label10.AutoSize                = $true
 $Label10.width                   = 25
 $Label10.height                  = 10
-$Label10.location                = New-Object System.Drawing.Point(657,430)
+$Label10.location                = New-Object System.Drawing.Point(658,448)
 $Label10.Font                    = New-Object System.Drawing.Font('Microsoft Sans Serif',24)
 
 $EHibernation                    = New-Object system.Windows.Forms.Button
@@ -624,14 +624,14 @@ $laptopnumlock                   = New-Object system.Windows.Forms.Button
 $laptopnumlock.text              = "Laptop Numlock Fix"
 $laptopnumlock.width             = 211
 $laptopnumlock.height            = 30
-$laptopnumlock.location          = New-Object System.Drawing.Point(4,267)
+$laptopnumlock.location          = New-Object System.Drawing.Point(4,301)
 $laptopnumlock.Font              = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
 $disableupdates                  = New-Object system.Windows.Forms.Button
 $disableupdates.text             = "Disable Update Services"
 $disableupdates.width            = 300
 $disableupdates.height           = 30
-$disableupdates.location         = New-Object System.Drawing.Point(24,282)
+$disableupdates.location         = New-Object System.Drawing.Point(24,251)
 $disableupdates.Font             = New-Object System.Drawing.Font('Microsoft Sans Serif',14)
 
 $enableupdates                   = New-Object system.Windows.Forms.Button
@@ -646,14 +646,21 @@ $Label12.text                    = "NOT RECOMMENDED!!!"
 $Label12.AutoSize                = $true
 $Label12.width                   = 25
 $Label12.height                  = 10
-$Label12.location                = New-Object System.Drawing.Point(102,262)
+$Label12.location                = New-Object System.Drawing.Point(98,236)
 $Label12.Font                    = New-Object System.Drawing.Font('Microsoft Sans Serif',10,[System.Drawing.FontStyle]([System.Drawing.FontStyle]::Bold))
+
+$Virtualization                  = New-Object system.Windows.Forms.Button
+$Virtualization.text             = "Enable HyperV + WSL"
+$Virtualization.width            = 211
+$Virtualization.height           = 30
+$Virtualization.location         = New-Object System.Drawing.Point(4,267)
+$Virtualization.Font             = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
 $Form.controls.AddRange(@($Panel1,$Panel2,$Label3,$Label15,$Panel4,$PictureBox1,$Label1,$Label4,$Panel3,$ResultText,$Label10,$Label11,$urlfixwinstartup,$urlremovevirus,$urlcreateiso))
 $Panel1.controls.AddRange(@($brave,$firefox,$7zip,$sharex,$adobereader,$notepad,$gchrome,$mpc,$vlc,$powertoys,$batchinstall,$vscode,$Label2,$everythingsearch,$sumatrapdf,$vscodium,$imageglass,$gimp,$Label7,$Label8,$Label9,$advancedipscanner,$putty,$etcher,$translucenttb,$githubdesktop,$discord,$autohotkey))
 $Panel2.controls.AddRange(@($essentialtweaks,$backgroundapps,$cortana,$actioncenter,$darkmode,$performancefx,$onedrive,$lightmode,$essentialundo,$EActionCenter,$ECortana,$RBackgroundApps,$HTrayIcons,$EClipboardHistory,$ELocation,$InstallOneDrive,$removebloat,$reinstallbloat,$WarningLabel,$Label5,$appearancefx,$STrayIcons,$EHibernation,$dualboottime))
 $Panel4.controls.AddRange(@($defaultwindowsupdate,$securitywindowsupdate,$Label16,$Label17,$Label18,$Label19,$disableupdates,$enableupdates,$Label12))
-$Panel3.controls.AddRange(@($yourphonefix,$Label6,$windowsupdatefix,$ncpa,$oldcontrolpanel,$oldsoundpanel,$oldsystempanel,$NFS,$laptopnumlock))
+$Panel3.controls.AddRange(@($yourphonefix,$Label6,$windowsupdatefix,$ncpa,$oldcontrolpanel,$oldsoundpanel,$oldsystempanel,$NFS,$laptopnumlock,$Virtualization))
 
 $brave.Add_Click({
     Write-Host "Installing Brave Browser"
@@ -1310,9 +1317,94 @@ $essentialundo.Add_Click({
     $ResultText.text = "`r`n" +"`r`n" + "Essential Undo Completed - Ready for next task"
 })
 
+$windowssearch.Add_Click({
+    Write-Host "Disabling Bing Search in Start Menu..."
+    $ResultText.text = "`r`n" +"`r`n" + "Disabling Search, Cortana, Start menu search... Please Wait"
+    Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Search" -Name "BingSearchEnabled" -Type DWord -Value 0
+    <#
+    Write-Host "Disabling Cortana"
+    Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Search" -Name "CortanaConsent" -Type DWord -Value 0
+    If (!(Test-Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Search")) {
+        New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Search" -Force | Out-Null
+    }
+    #>
+    Write-Host "Hiding Search Box / Button..."
+    Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Search" -Name "SearchboxTaskbarMode" -Type DWord -Value 0
+
+    Write-Host "Removing Start Menu Tiles"
+
+    Set-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -Value '<LayoutModificationTemplate xmlns:defaultlayout="http://schemas.microsoft.com/Start/2014/FullDefaultLayout" xmlns:start="http://schemas.microsoft.com/Start/2014/StartLayout" Version="1" xmlns="http://schemas.microsoft.com/Start/2014/LayoutModification">'
+    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '  <LayoutOptions StartTileGroupCellWidth="6" />'
+    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '  <DefaultLayoutOverride>'
+    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '    <StartLayoutCollection>'
+    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '      <defaultlayout:StartLayout GroupCellWidth="6" />'
+    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '    </StartLayoutCollection>'
+    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '  </DefaultLayoutOverride>'
+    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '    <CustomTaskbarLayoutCollection>'
+    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '      <defaultlayout:TaskbarLayout>'
+    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '        <taskbar:TaskbarPinList>'
+    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '          <taskbar:UWA AppUserModelID="Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge" />'
+    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '          <taskbar:DesktopApp DesktopApplicationLinkPath="%APPDATA%\Microsoft\Windows\Start Menu\Programs\System Tools\File Explorer.lnk" />'
+    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '        </taskbar:TaskbarPinList>'
+    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '      </defaultlayout:TaskbarLayout>'
+    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '    </CustomTaskbarLayoutCollection>'
+    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '</LayoutModificationTemplate>'
+
+    $START_MENU_LAYOUT = @"
+    <LayoutModificationTemplate xmlns:defaultlayout="http://schemas.microsoft.com/Start/2014/FullDefaultLayout" xmlns:start="http://schemas.microsoft.com/Start/2014/StartLayout" Version="1" xmlns:taskbar="http://schemas.microsoft.com/Start/2014/TaskbarLayout" xmlns="http://schemas.microsoft.com/Start/2014/LayoutModification">
+        <LayoutOptions StartTileGroupCellWidth="6" />
+        <DefaultLayoutOverride>
+            <StartLayoutCollection>
+                <defaultlayout:StartLayout GroupCellWidth="6" />
+            </StartLayoutCollection>
+        </DefaultLayoutOverride>
+    </LayoutModificationTemplate>
+"@
+
+    $layoutFile="C:\Windows\StartMenuLayout.xml"
+
+    #Delete layout file if it already exists
+    If(Test-Path $layoutFile)
+    {
+        Remove-Item $layoutFile
+    }
+
+    #Creates the blank layout file
+    $START_MENU_LAYOUT | Out-File $layoutFile -Encoding ASCII
+
+    $regAliases = @("HKLM", "HKCU")
+
+    #Assign the start layout and force it to apply with "LockedStartLayout" at both the machine and user level
+    foreach ($regAlias in $regAliases){
+        $basePath = $regAlias + ":\SOFTWARE\Policies\Microsoft\Windows"
+        $keyPath = $basePath + "\Explorer"
+        IF(!(Test-Path -Path $keyPath)) {
+            New-Item -Path $basePath -Name "Explorer"
+        }
+        Set-ItemProperty -Path $keyPath -Name "LockedStartLayout" -Value 1
+        Set-ItemProperty -Path $keyPath -Name "StartLayoutFile" -Value $layoutFile
+    }
+
+    #Restart Explorer, open the start menu (necessary to load the new layout), and give it a few seconds to process
+    Stop-Process -name explorer
+    Start-Sleep -s 5
+    $wshell = New-Object -ComObject wscript.shell; $wshell.SendKeys('^{ESCAPE}')
+    Start-Sleep -s 5
+
+    #Enable the ability to pin items again by disabling "LockedStartLayout"
+    foreach ($regAlias in $regAliases){
+        $basePath = $regAlias + ":\SOFTWARE\Policies\Microsoft\Windows"
+        $keyPath = $basePath + "\Explorer"
+        Set-ItemProperty -Path $keyPath -Name "LockedStartLayout" -Value 0
+
+    Write-Host "Search and Start Menu Tweaks Complete"
+    $ResultText.text = "`r`n" +"`r`n" + "Search and Start Menu Tweaks Complete"
+    }
+})
+
 $backgroundapps.Add_Click({
     Write-Host "Disabling Background application access..."
-    Get-ChildItem -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" -Exclude "Microsoft.Windows.Cortana*" | ForEach-Object {
+    Get-ChildItem -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" -Exclude "Microsoft.Windows.Cortana*" | ForEach {
         Set-ItemProperty -Path $_.PsPath -Name "Disabled" -Type DWord -Value 1
         Set-ItemProperty -Path $_.PsPath -Name "DisabledByUser" -Type DWord -Value 1
     }
@@ -1665,7 +1757,7 @@ $ELocation.Add_Click({
 
 $RBackgroundApps.Add_Click({
 	Write-Host "Allowing Background Apps..."
-	Get-ChildItem -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" -Exclude "Microsoft.Windows.Cortana*" | ForEach-Object {
+	Get-ChildItem -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" -Exclude "Microsoft.Windows.Cortana*" | ForEach {
 		Remove-ItemProperty -Path $_.PsPath -Name "Disabled" -ErrorAction SilentlyContinue
 		Remove-ItemProperty -Path $_.PsPath -Name "DisabledByUser" -ErrorAction SilentlyContinue
 	}
@@ -1707,7 +1799,7 @@ $yourphonefix.Add_Click({
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" -Name "EnableCdp" -Type DWord -Value 1
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Messaging" -Name "AllowMessageSync" -Type DWord -Value 1
     Write-Host "Allowing Background Apps..."
-	Get-ChildItem -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" -Exclude "Microsoft.Windows.Cortana*" | ForEach-Object {
+	Get-ChildItem -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" -Exclude "Microsoft.Windows.Cortana*" | ForEach {
 		Remove-ItemProperty -Path $_.PsPath -Name "Disabled" -ErrorAction SilentlyContinue
 		Remove-ItemProperty -Path $_.PsPath -Name "DisabledByUser" -ErrorAction SilentlyContinue
 	}
@@ -1739,6 +1831,23 @@ $NFS.Add_Click({
     Write-Host "NFS is now setup for user based NFS mounts"
     $ResultText.text = "`r`n" +"`r`n" + "NFS is now setup for user based NFS mounts"
 })
+
+$Virtualization.Add_Click({
+    Enable-WindowsOptionalFeature -Online -FeatureName "HypervisorPlatform" -All
+    Enable-WindowsOptionalFeature -Online -FeatureName "VirtualMachinePlatform" -All
+    Enable-WindowsOptionalFeature -Online -FeatureName "Microsoft-Windows-Subsystem-Linux" -All
+    Enable-WindowsOptionalFeature -Online -FeatureName "Microsoft-Hyper-V-All" -All
+    Enable-WindowsOptionalFeature -Online -FeatureName "Microsoft-Hyper-V" -All
+    Enable-WindowsOptionalFeature -Online -FeatureName "Microsoft-Hyper-V-Tools-All" -All
+    Enable-WindowsOptionalFeature -Online -FeatureName "Microsoft-Hyper-V-Management-PowerShell" -All
+    Enable-WindowsOptionalFeature -Online -FeatureName "Microsoft-Hyper-V-Hypervisor" -All
+    Enable-WindowsOptionalFeature -Online -FeatureName "Microsoft-Hyper-V-Services" -All
+    Enable-WindowsOptionalFeature -Online -FeatureName "Microsoft-Hyper-V-Management-Clients" -All
+    cmd /c bcdedit /set hypervisorschedulertype classic
+    Write-Host "HyperV is now installed and configured. Please Reboot before using."
+    $ResultText.text = "`r`n" +"`r`n" + "HyperV is now installed and configured. Please Reboot before using."
+})
+
 $windowsupdatefix.Add_Click({
     Write-Host "1. Stopping Windows Update Services..." 
     Stop-Service -Name BITS 

--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -12,12 +12,12 @@ Write-Host "Checking for Winget..."
 if (!(Test-Path ~\AppData\Local\Microsoft\WindowsApps\winget.exe)){  
     Write-Host "Winget not Found, Installing Now."
 	# "ms-appinstaller" Method Disabled for Now Because of Security Vulnerabilities
-    	#Start-Process "ms-appinstaller:?source=https://aka.ms/getwinget"
-    	Start-BitsTransfer "https://aka.ms/getwinget" .\Microsoft.DesktopAppInstaller.msixbundle
-    	./Microsoft.DesktopAppInstaller.msixbundle
+    #Start-Process "ms-appinstaller:?source=https://aka.ms/getwinget"
+    Start-BitsTransfer "https://aka.ms/getwinget" .\Microsoft.DesktopAppInstaller.msixbundle
+    ./Microsoft.DesktopAppInstaller.msixbundle
 	$nid = (Get-Process AppInstaller).Id
-    	Wait-Process -Id $nid
-    	Write-Host "Winget Installed"
+    Wait-Process -Id $nid
+    Write-Host "Winget Installed"
     $ResultText.text = "`r`n" +"`r`n" + "Winget Installed - Ready for Next Task"
 }
 
@@ -213,9 +213,9 @@ $Label15.location                = New-Object System.Drawing.Point(732,11)
 $Label15.Font                    = New-Object System.Drawing.Font('Microsoft Sans Serif',24)
 
 $Panel4                          = New-Object system.Windows.Forms.Panel
-$Panel4.height                   = 179
+$Panel4.height                   = 328
 $Panel4.width                    = 340
-$Panel4.location                 = New-Object System.Drawing.Point(699,55)
+$Panel4.location                 = New-Object System.Drawing.Point(699,54)
 
 $defaultwindowsupdate            = New-Object system.Windows.Forms.Button
 $defaultwindowsupdate.text       = "Default Settings"
@@ -606,12 +606,12 @@ $oldsoundpanel.height            = 30
 $oldsoundpanel.location          = New-Object System.Drawing.Point(4,163)
 $oldsoundpanel.Font              = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
-$oldsystempanel                         = New-Object system.Windows.Forms.Button
-$oldsystempanel.text                    = "Old System Panel"
-$oldsystempanel.width                   = 211
-$oldsystempanel.height                  = 30
-$oldsystempanel.location                = New-Object System.Drawing.Point(4,197)
-$oldsystempanel.Font                    = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
+$oldsystempanel                  = New-Object system.Windows.Forms.Button
+$oldsystempanel.text             = "Old System Panel"
+$oldsystempanel.width            = 211
+$oldsystempanel.height           = 30
+$oldsystempanel.location         = New-Object System.Drawing.Point(4,197)
+$oldsystempanel.Font             = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
 $NFS                             = New-Object system.Windows.Forms.Button
 $NFS.text                        = "Enable NFS"
@@ -620,11 +620,40 @@ $NFS.height                      = 30
 $NFS.location                    = New-Object System.Drawing.Point(4,232)
 $NFS.Font                        = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
+$laptopnumlock                   = New-Object system.Windows.Forms.Button
+$laptopnumlock.text              = "Laptop Numlock Fix"
+$laptopnumlock.width             = 211
+$laptopnumlock.height            = 30
+$laptopnumlock.location          = New-Object System.Drawing.Point(4,267)
+$laptopnumlock.Font              = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
+
+$disableupdates                  = New-Object system.Windows.Forms.Button
+$disableupdates.text             = "Disable Update Services"
+$disableupdates.width            = 300
+$disableupdates.height           = 30
+$disableupdates.location         = New-Object System.Drawing.Point(24,282)
+$disableupdates.Font             = New-Object System.Drawing.Font('Microsoft Sans Serif',14)
+
+$enableupdates                   = New-Object system.Windows.Forms.Button
+$enableupdates.text              = "Enable Update Services"
+$enableupdates.width             = 300
+$enableupdates.height            = 30
+$enableupdates.location          = New-Object System.Drawing.Point(25,179)
+$enableupdates.Font              = New-Object System.Drawing.Font('Microsoft Sans Serif',14)
+
+$Label12                         = New-Object system.Windows.Forms.Label
+$Label12.text                    = "NOT RECOMMENDED!!!"
+$Label12.AutoSize                = $true
+$Label12.width                   = 25
+$Label12.height                  = 10
+$Label12.location                = New-Object System.Drawing.Point(102,262)
+$Label12.Font                    = New-Object System.Drawing.Font('Microsoft Sans Serif',10,[System.Drawing.FontStyle]([System.Drawing.FontStyle]::Bold))
+
 $Form.controls.AddRange(@($Panel1,$Panel2,$Label3,$Label15,$Panel4,$PictureBox1,$Label1,$Label4,$Panel3,$ResultText,$Label10,$Label11,$urlfixwinstartup,$urlremovevirus,$urlcreateiso))
 $Panel1.controls.AddRange(@($brave,$firefox,$7zip,$sharex,$adobereader,$notepad,$gchrome,$mpc,$vlc,$powertoys,$batchinstall,$vscode,$Label2,$everythingsearch,$sumatrapdf,$vscodium,$imageglass,$gimp,$Label7,$Label8,$Label9,$advancedipscanner,$putty,$etcher,$translucenttb,$githubdesktop,$discord,$autohotkey))
 $Panel2.controls.AddRange(@($essentialtweaks,$backgroundapps,$cortana,$actioncenter,$darkmode,$performancefx,$onedrive,$lightmode,$essentialundo,$EActionCenter,$ECortana,$RBackgroundApps,$HTrayIcons,$EClipboardHistory,$ELocation,$InstallOneDrive,$removebloat,$reinstallbloat,$WarningLabel,$Label5,$appearancefx,$STrayIcons,$EHibernation,$dualboottime))
-$Panel4.controls.AddRange(@($defaultwindowsupdate,$securitywindowsupdate,$Label16,$Label17,$Label18,$Label19))
-$Panel3.controls.AddRange(@($yourphonefix,$Label6,$windowsupdatefix,$ncpa,$oldcontrolpanel,$oldsoundpanel,$oldsystempanel,$NFS))
+$Panel4.controls.AddRange(@($defaultwindowsupdate,$securitywindowsupdate,$Label16,$Label17,$Label18,$Label19,$disableupdates,$enableupdates,$Label12))
+$Panel3.controls.AddRange(@($yourphonefix,$Label6,$windowsupdatefix,$ncpa,$oldcontrolpanel,$oldsoundpanel,$oldsystempanel,$NFS,$laptopnumlock))
 
 $brave.Add_Click({
     Write-Host "Installing Brave Browser"
@@ -1157,6 +1186,15 @@ Write-Host "Setting BIOS time to UTC..."
     $ResultText.text = "`r`n" + "Time set to UTC for consistent time in Dual Boot Systems" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
 
+$laptopnumlock.Add_Click({
+    Set-ItemProperty -Path "HKU:\.DEFAULT\Control Panel\Keyboard" -Name "InitialKeyboardIndicators" -Type DWord -Value 0
+    Add-Type -AssemblyName System.Windows.Forms
+    If (([System.Windows.Forms.Control]::IsKeyLocked('NumLock'))) {
+        $wsh = New-Object -ComObject WScript.Shell
+        $wsh.SendKeys('{NUMLOCK}')
+    }
+})
+
 $essentialundo.Add_Click({
     Write-Host "Creating Restore Point incase something bad happens"
     $ResultText.text = "`r`n" +"`r`n" + "Creating Restore Point and Reverting Settings... Please Wait"
@@ -1650,6 +1688,17 @@ $InstallOneDrive.Add_Click({
     $ResultText.text = "`r`n" +"`r`n" + "Finished Reinstalling OneDrive"
 })
 
+$DisableNumLock.Add_Click({
+    Write-Host "Disable NumLock after startup..."
+    Set-ItemProperty -Path "HKU:\.DEFAULT\Control Panel\Keyboard" -Name "InitialKeyboardIndicators" -Type DWord -Value 0
+    Add-Type -AssemblyName System.Windows.Forms
+    If (([System.Windows.Forms.Control]::IsKeyLocked('NumLock'))) {
+        $wsh = New-Object -ComObject WScript.Shell
+        $wsh.SendKeys('{NUMLOCK}')
+    }
+    $ResultText.text = "`r`n" +"`r`n" + "NUMLOCK Disabled"
+})
+
 $yourphonefix.Add_Click({
     Write-Host "Reinstalling Your Phone App"
     Add-AppxPackage -DisableDevelopmentMode -Register "$($(Get-AppXPackage -AllUsers "Microsoft.YourPhone").InstallLocation)\AppXManifest.xml"
@@ -1690,7 +1739,6 @@ $NFS.Add_Click({
     Write-Host "NFS is now setup for user based NFS mounts"
     $ResultText.text = "`r`n" +"`r`n" + "NFS is now setup for user based NFS mounts"
 })
-
 $windowsupdatefix.Add_Click({
     Write-Host "1. Stopping Windows Update Services..." 
     Stop-Service -Name BITS 
@@ -1784,6 +1832,178 @@ $windowsupdatefix.Add_Click({
     Write-Host "Process complete. Please reboot your computer."
     $ResultText.text = "`r`n" +"`r`n" + "Process complete. Please reboot your computer."
 
+})
+
+$disableupdates.Add_Click({
+
+    # Source: https://github.com/rgl/windows-vagrant/blob/master/disable-windows-updates.ps1
+    Set-StrictMode -Version Latest
+$ProgressPreference = 'SilentlyContinue'
+$ErrorActionPreference = 'Stop'
+trap {
+    Write-Host
+    Write-Host "ERROR: $_"
+    Write-Host (($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1')
+    Write-Host (($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1')
+    Write-Host
+    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
+    Start-Sleep -Seconds (60*60)
+    Exit 1
+}
+
+# disable automatic updates.
+# XXX this does not seem to work anymore.
+# see How to configure automatic updates by using Group Policy or registry settings
+#     at https://support.microsoft.com/en-us/help/328010
+function New-Directory($path) {
+    $p, $components = $path -split '[\\/]'
+    $components | ForEach-Object {
+        $p = "$p\$_"
+        if (!(Test-Path $p)) {
+            New-Item -ItemType Directory $p | Out-Null
+        }
+    }
+    $null
+}
+$auPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU'
+New-Directory $auPath 
+# set NoAutoUpdate.
+# 0: Automatic Updates is enabled (default).
+# 1: Automatic Updates is disabled.
+New-ItemProperty `
+    -Path $auPath `
+    -Name NoAutoUpdate `
+    -Value 1 `
+    -PropertyType DWORD `
+    -Force `
+    | Out-Null
+# set AUOptions.
+# 1: Keep my computer up to date has been disabled in Automatic Updates.
+# 2: Notify of download and installation.
+# 3: Automatically download and notify of installation.
+# 4: Automatically download and scheduled installation.
+New-ItemProperty `
+    -Path $auPath `
+    -Name AUOptions `
+    -Value 1 `
+    -PropertyType DWORD `
+    -Force `
+    | Out-Null
+
+# disable Windows Update Delivery Optimization.
+# NB this applies to Windows 10.
+# 0: Disabled
+# 1: PCs on my local network
+# 3: PCs on my local network, and PCs on the Internet
+$deliveryOptimizationPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Config'
+if (Test-Path $deliveryOptimizationPath) {
+    New-ItemProperty `
+        -Path $deliveryOptimizationPath `
+        -Name DODownloadMode `
+        -Value 0 `
+        -PropertyType DWORD `
+        -Force `
+        | Out-Null
+}
+# Service tweaks for Windows Update
+
+$services = @(
+    "BITS"
+    "wuauserv"
+)
+
+foreach ($service in $services) {
+    # -ErrorAction SilentlyContinue is so it doesn't write an error to stdout if a service doesn't exist
+
+    Write-Host "Setting $service StartupType to Disabled"
+    Get-Service -Name $service -ErrorAction SilentlyContinue | Set-Service -StartupType Disabled
+}
+})
+
+$enableupdates.Add_Click({
+
+    # Source: https://github.com/rgl/windows-vagrant/blob/master/disable-windows-updates.ps1
+    Set-StrictMode -Version Latest
+$ProgressPreference = 'SilentlyContinue'
+$ErrorActionPreference = 'Stop'
+trap {
+    Write-Host
+    Write-Host "ERROR: $_"
+    Write-Host (($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1')
+    Write-Host (($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1')
+    Write-Host
+    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
+    Start-Sleep -Seconds (60*60)
+    Exit 1
+}
+
+# disable automatic updates.
+# XXX this does not seem to work anymore.
+# see How to configure automatic updates by using Group Policy or registry settings
+#     at https://support.microsoft.com/en-us/help/328010
+function New-Directory($path) {
+    $p, $components = $path -split '[\\/]'
+    $components | ForEach-Object {
+        $p = "$p\$_"
+        if (!(Test-Path $p)) {
+            New-Item -ItemType Directory $p | Out-Null
+        }
+    }
+    $null
+}
+$auPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU'
+New-Directory $auPath 
+# set NoAutoUpdate.
+# 0: Automatic Updates is enabled (default).
+# 1: Automatic Updates is disabled.
+New-ItemProperty `
+    -Path $auPath `
+    -Name NoAutoUpdate `
+    -Value 0 `
+    -PropertyType DWORD `
+    -Force `
+    | Out-Null
+# set AUOptions.
+# 1: Keep my computer up to date has been disabled in Automatic Updates.
+# 2: Notify of download and installation.
+# 3: Automatically download and notify of installation.
+# 4: Automatically download and scheduled installation.
+New-ItemProperty `
+    -Path $auPath `
+    -Name AUOptions `
+    -Value 3 `
+    -PropertyType DWORD `
+    -Force `
+    | Out-Null
+
+# disable Windows Update Delivery Optimization.
+# NB this applies to Windows 10.
+# 0: Disabled
+# 1: PCs on my local network
+# 3: PCs on my local network, and PCs on the Internet
+$deliveryOptimizationPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Config'
+if (Test-Path $deliveryOptimizationPath) {
+    New-ItemProperty `
+        -Path $deliveryOptimizationPath `
+        -Name DODownloadMode `
+        -Value 0 `
+        -PropertyType DWORD `
+        -Force `
+        | Out-Null
+}
+# Service tweaks for Windows Update
+
+$services = @(
+    "BITS"
+    "wuauserv"
+)
+
+foreach ($service in $services) {
+    # -ErrorAction SilentlyContinue is so it doesn't write an error to stdout if a service doesn't exist
+
+    Write-Host "Setting $service StartupType to Automatic"
+    Get-Service -Name $service -ErrorAction SilentlyContinue | Set-Service -StartupType Automatic
+}
 })
 
 [void]$Form.ShowDialog()

--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -1,27 +1,25 @@
 Add-Type -AssemblyName System.Windows.Forms
 [System.Windows.Forms.Application]::EnableVisualStyles()
 
-# Get Admin Privilages
+$ErrorActionPreference = 'SilentlyContinue'
+$wshell = New-Object -ComObject Wscript.Shell
+$Button = [System.Windows.MessageBoxButton]::YesNoCancel
+$ErrorIco = [System.Windows.MessageBoxImage]::Error
 If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]'Administrator')) {
 	Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`"" -Verb RunAs
 	Exit
 }
 
-# Check if WinGet is Installed, if Not Install From MS Store
-Write-Host "Checking for Winget..."
-if (!(Test-Path ~\AppData\Local\Microsoft\WindowsApps\winget.exe)){  
-    Write-Host "Winget not Found, Installing Now."
-	# "ms-appinstaller" Method Disabled for Now Because of Security Vulnerabilities
-    #Start-Process "ms-appinstaller:?source=https://aka.ms/getwinget"
-    Start-BitsTransfer "https://aka.ms/getwinget" .\Microsoft.DesktopAppInstaller.msixbundle
-    ./Microsoft.DesktopAppInstaller.msixbundle
-	$nid = (Get-Process AppInstaller).Id
-    Wait-Process -Id $nid
-    Write-Host "Winget Installed"
+# Check if Winget is Installed, if not Install From GitHub
+if (!(Test-Path ~\AppData\Local\Microsoft\WindowsApps\winget.exe)){
+    Write-Host "Winget not Found, Installing Now..."
+    $ResultText.text = "`r`n" +"`r`n" + "Installing Winget... Please Wait"
+    $latest = (Invoke-WebRequest -UseBasicParsing -URI "https://github.com/microsoft/winget-cli/releases/latest").Links.Href | Select-String ".msixbundle"
+    Start-BitsTransfer "https://github.com$latest"; .\Microsoft.DesktopAppInstaller_*.msixbundle
+    Write-Host "Winget Successfully Installed"
     $ResultText.text = "`r`n" +"`r`n" + "Winget Installed - Ready for Next Task"
 }
 
-# GUI Specs
 $Form                            = New-Object system.Windows.Forms.Form
 $Form.ClientSize                 = New-Object System.Drawing.Point(1050,1000)
 $Form.text                       = "Windows Toolbox By Chris Titus"
@@ -152,7 +150,7 @@ $Label3.text                     = "System Tweaks"
 $Label3.AutoSize                 = $true
 $Label3.width                    = 230
 $Label3.height                   = 25
-$Label3.location                 = New-Object System.Drawing.Point(229,11)
+$Label3.location                 = New-Object System.Drawing.Point(349,11)
 $Label3.Font                     = New-Object System.Drawing.Font('Microsoft Sans Serif',24)
 
 $essentialtweaks                 = New-Object system.Windows.Forms.Button
@@ -284,16 +282,8 @@ $Label1.height                   = 25
 $Label1.location                 = New-Object System.Drawing.Point(76,11)
 $Label1.Font                     = New-Object System.Drawing.Font('Microsoft Sans Serif',24)
 
-$Label4                          = New-Object system.Windows.Forms.Label
-$Label4.text                     = "Troubleshoot"
-$Label4.AutoSize                 = $true
-$Label4.width                    = 230
-$Label4.height                   = 25
-$Label4.location                 = New-Object System.Drawing.Point(482,12)
-$Label4.Font                     = New-Object System.Drawing.Font('Microsoft Sans Serif',24)
-
 $Panel3                          = New-Object system.Windows.Forms.Panel
-$Panel3.height                   = 363
+$Panel3.height                   = 381
 $Panel3.width                    = 220
 $Panel3.location                 = New-Object System.Drawing.Point(464,54)
 
@@ -392,7 +382,7 @@ $yourphonefix                    = New-Object system.Windows.Forms.Button
 $yourphonefix.text               = "Your Phone App Fix"
 $yourphonefix.width              = 211
 $yourphonefix.height             = 30
-$yourphonefix.location           = New-Object System.Drawing.Point(4,25)
+$yourphonefix.location           = New-Object System.Drawing.Point(5,332)
 $yourphonefix.Font               = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
 $removebloat                     = New-Object system.Windows.Forms.Button
@@ -424,14 +414,6 @@ $Label5.width                    = 25
 $Label5.height                   = 10
 $Label5.location                 = New-Object System.Drawing.Point(44,877)
 $Label5.Font                     = New-Object System.Drawing.Font('Microsoft Sans Serif',8)
-
-$Label6                          = New-Object system.Windows.Forms.Label
-$Label6.text                     = "Misc. Fixes"
-$Label6.AutoSize                 = $true
-$Label6.width                    = 25
-$Label6.height                   = 10
-$Label6.location                 = New-Object System.Drawing.Point(78,7)
-$Label6.Font                     = New-Object System.Drawing.Font('Microsoft Sans Serif',10,[System.Drawing.FontStyle]([System.Drawing.FontStyle]::Bold))
 
 $Label7                          = New-Object system.Windows.Forms.Label
 $Label7.text                     = "Document Tools"
@@ -465,7 +447,7 @@ $advancedipscanner.location      = New-Object System.Drawing.Point(3,335)
 $advancedipscanner.Font          = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
 $putty                           = New-Object system.Windows.Forms.Button
-$putty.text                      = "PuTTY + WinSCP"
+$putty.text                      = "PuTTY & WinSCP"
 $putty.width                     = 211
 $putty.height                    = 30
 $putty.location                  = New-Object System.Drawing.Point(3,302)
@@ -522,10 +504,10 @@ $STrayIcons.Font                 = New-Object System.Drawing.Font('Microsoft San
 
 $windowsupdatefix                = New-Object system.Windows.Forms.Button
 $windowsupdatefix.text           = "Windows Update Reset"
-$windowsupdatefix.width          = 211
+$windowsupdatefix.width          = 300
 $windowsupdatefix.height         = 30
-$windowsupdatefix.location       = New-Object System.Drawing.Point(4,59)
-$windowsupdatefix.Font           = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
+$windowsupdatefix.location       = New-Object System.Drawing.Point(25,216)
+$windowsupdatefix.Font           = New-Object System.Drawing.Font('Microsoft Sans Serif',14)
 
 $ResultText                      = New-Object system.Windows.Forms.TextBox
 $ResultText.multiline            = $true
@@ -589,49 +571,49 @@ $ncpa                            = New-Object system.Windows.Forms.Button
 $ncpa.text                       = "Network Connections"
 $ncpa.width                      = 211
 $ncpa.height                     = 30
-$ncpa.location                   = New-Object System.Drawing.Point(4,94)
+$ncpa.location                   = New-Object System.Drawing.Point(4,126)
 $ncpa.Font                       = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
 $oldcontrolpanel                 = New-Object system.Windows.Forms.Button
-$oldcontrolpanel.text            = "Old Control Panel"
+$oldcontrolpanel.text            = "Win7 Control Panel"
 $oldcontrolpanel.width           = 211
 $oldcontrolpanel.height          = 30
-$oldcontrolpanel.location        = New-Object System.Drawing.Point(4,128)
+$oldcontrolpanel.location        = New-Object System.Drawing.Point(4,193)
 $oldcontrolpanel.Font            = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
 $oldsoundpanel                   = New-Object system.Windows.Forms.Button
-$oldsoundpanel.text              = "Old Sound Panel"
+$oldsoundpanel.text              = "Win7 Sound Panel"
 $oldsoundpanel.width             = 211
 $oldsoundpanel.height            = 30
-$oldsoundpanel.location          = New-Object System.Drawing.Point(4,163)
+$oldsoundpanel.location          = New-Object System.Drawing.Point(5,262)
 $oldsoundpanel.Font              = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
 $oldsystempanel                  = New-Object system.Windows.Forms.Button
-$oldsystempanel.text             = "Old System Panel"
+$oldsystempanel.text             = "Win7 System Panel"
 $oldsystempanel.width            = 211
 $oldsystempanel.height           = 30
-$oldsystempanel.location         = New-Object System.Drawing.Point(4,197)
+$oldsystempanel.location         = New-Object System.Drawing.Point(5,298)
 $oldsystempanel.Font             = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
 $NFS                             = New-Object system.Windows.Forms.Button
 $NFS.text                        = "Enable NFS"
 $NFS.width                       = 211
 $NFS.height                      = 30
-$NFS.location                    = New-Object System.Drawing.Point(4,232)
+$NFS.location                    = New-Object System.Drawing.Point(4,57)
 $NFS.Font                        = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
 $laptopnumlock                   = New-Object system.Windows.Forms.Button
 $laptopnumlock.text              = "Laptop Numlock Fix"
 $laptopnumlock.width             = 211
 $laptopnumlock.height            = 30
-$laptopnumlock.location          = New-Object System.Drawing.Point(4,301)
+$laptopnumlock.location          = New-Object System.Drawing.Point(4,92)
 $laptopnumlock.Font              = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
 $disableupdates                  = New-Object system.Windows.Forms.Button
 $disableupdates.text             = "Disable Update Services"
 $disableupdates.width            = 300
 $disableupdates.height           = 30
-$disableupdates.location         = New-Object System.Drawing.Point(24,251)
+$disableupdates.location         = New-Object System.Drawing.Point(23,292)
 $disableupdates.Font             = New-Object System.Drawing.Font('Microsoft Sans Serif',14)
 
 $enableupdates                   = New-Object system.Windows.Forms.Button
@@ -646,21 +628,35 @@ $Label12.text                    = "NOT RECOMMENDED!!!"
 $Label12.AutoSize                = $true
 $Label12.width                   = 25
 $Label12.height                  = 10
-$Label12.location                = New-Object System.Drawing.Point(98,236)
+$Label12.location                = New-Object System.Drawing.Point(98,275)
 $Label12.Font                    = New-Object System.Drawing.Font('Microsoft Sans Serif',10,[System.Drawing.FontStyle]([System.Drawing.FontStyle]::Bold))
 
 $Virtualization                  = New-Object system.Windows.Forms.Button
 $Virtualization.text             = "Enable HyperV + WSL"
 $Virtualization.width            = 211
 $Virtualization.height           = 30
-$Virtualization.location         = New-Object System.Drawing.Point(4,267)
+$Virtualization.location         = New-Object System.Drawing.Point(4,23)
 $Virtualization.Font             = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
-$Form.controls.AddRange(@($Panel1,$Panel2,$Label3,$Label15,$Panel4,$PictureBox1,$Label1,$Label4,$Panel3,$ResultText,$Label10,$Label11,$urlfixwinstartup,$urlremovevirus,$urlcreateiso))
+$oldpower                        = New-Object system.Windows.Forms.Button
+$oldpower.text                   = "Win7 Power Panel"
+$oldpower.width                  = 211
+$oldpower.height                 = 30
+$oldpower.location               = New-Object System.Drawing.Point(4,227)
+$oldpower.Font                   = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
+
+$restorepower                    = New-Object system.Windows.Forms.Button
+$restorepower.text               = "Restore Power Options"
+$restorepower.width              = 211
+$restorepower.height             = 30
+$restorepower.location           = New-Object System.Drawing.Point(4,159)
+$restorepower.Font               = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
+
+$Form.controls.AddRange(@($Panel1,$Panel2,$Label3,$Label15,$Panel4,$PictureBox1,$Label1,$Panel3,$ResultText,$Label10,$Label11,$urlfixwinstartup,$urlremovevirus,$urlcreateiso))
 $Panel1.controls.AddRange(@($brave,$firefox,$7zip,$sharex,$adobereader,$notepad,$gchrome,$mpc,$vlc,$powertoys,$batchinstall,$vscode,$Label2,$everythingsearch,$sumatrapdf,$vscodium,$imageglass,$gimp,$Label7,$Label8,$Label9,$advancedipscanner,$putty,$etcher,$translucenttb,$githubdesktop,$discord,$autohotkey))
 $Panel2.controls.AddRange(@($essentialtweaks,$backgroundapps,$cortana,$actioncenter,$darkmode,$performancefx,$onedrive,$lightmode,$essentialundo,$EActionCenter,$ECortana,$RBackgroundApps,$HTrayIcons,$EClipboardHistory,$ELocation,$InstallOneDrive,$removebloat,$reinstallbloat,$WarningLabel,$Label5,$appearancefx,$STrayIcons,$EHibernation,$dualboottime))
-$Panel4.controls.AddRange(@($defaultwindowsupdate,$securitywindowsupdate,$Label16,$Label17,$Label18,$Label19,$disableupdates,$enableupdates,$Label12))
-$Panel3.controls.AddRange(@($yourphonefix,$Label6,$windowsupdatefix,$ncpa,$oldcontrolpanel,$oldsoundpanel,$oldsystempanel,$NFS,$laptopnumlock,$Virtualization))
+$Panel4.controls.AddRange(@($defaultwindowsupdate,$securitywindowsupdate,$Label16,$Label17,$Label18,$Label19,$windowsupdatefix,$disableupdates,$enableupdates,$Label12))
+$Panel3.controls.AddRange(@($yourphonefix,$ncpa,$oldcontrolpanel,$oldsoundpanel,$oldsystempanel,$NFS,$laptopnumlock,$Virtualization,$oldpower,$restorepower))
 
 $brave.Add_Click({
     Write-Host "Installing Brave Browser"
@@ -784,6 +780,7 @@ $batchinstall.Add_Click({
         "7-Zip"
         "AutoHotkey"
         "Discord"
+        "BleachBit"
         "GitHub Desktop"
         "TranslucentTB"
         "balenaEtcher"
@@ -1818,6 +1815,16 @@ $oldcontrolpanel.Add_Click({
 })
 $oldsystempanel.Add_Click({
     cmd /c sysdm.cpl
+})
+$oldpower.Add_Click({
+    cmd /c powercfg.cpl
+})
+$restorepower.Add_Click({
+    powercfg -duplicatescheme a1841308-3541-4fab-bc81-f71556f20b4a
+    powercfg -duplicatescheme 381b4222-f694-41f0-9685-ff5bb260df2e
+    powercfg -duplicatescheme e9a42b02-d5df-448d-aa00-03f14749eb61
+    Write-Host "Restored all power plans: Balanced, High Performance, and Power Saver"
+    $ResultText.text = "`r`n" +"`r`n" + "Restored all power plans: Balanced, High Performance, and Power Saver"
 })
 $NFS.Add_Click({
     Enable-WindowsOptionalFeature -Online -FeatureName "ServicesForNFS-ClientOnly" -All

--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -8,13 +8,16 @@ If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
 }
 
 # Check if WinGet is Installed, if Not Install From MS Store
-Write-Host "Checking Winget..."
+Write-Host "Checking for Winget..."
 if (!(Test-Path ~\AppData\Local\Microsoft\WindowsApps\winget.exe)){  
     Write-Host "Winget not Found, Installing Now."
-	Start-Process "ms-appinstaller:?source=https://aka.ms/getwinget"
+	# "ms-appinstaller" Method Disabled for Now Because of Security Vulnerabilities
+    	#Start-Process "ms-appinstaller:?source=https://aka.ms/getwinget"
+    	Start-BitsTransfer "https://aka.ms/getwinget" .\Microsoft.DesktopAppInstaller.msixbundle
+    	./Microsoft.DesktopAppInstaller.msixbundle
 	$nid = (Get-Process AppInstaller).Id
-	Wait-Process -Id $nid
-	Write-Host "Winget Installed"
+    	Wait-Process -Id $nid
+    	Write-Host "Winget Installed"
     $ResultText.text = "`r`n" +"`r`n" + "Winget Installed - Ready for Next Task"
 }
 

--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -1,33 +1,24 @@
 Add-Type -AssemblyName System.Windows.Forms
 [System.Windows.Forms.Application]::EnableVisualStyles()
 
-$ErrorActionPreference = 'SilentlyContinue'
-$wshell = New-Object -ComObject Wscript.Shell
-$Button = [System.Windows.MessageBoxButton]::YesNoCancel
-$ErrorIco = [System.Windows.MessageBoxImage]::Error
+# Get Admin Privilages
 If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]'Administrator')) {
 	Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`"" -Verb RunAs
 	Exit
 }
 
-# GUI Specs
-Write-Host "Checking winget..."
-
-# Check if winget is installed
-if (Test-Path ~\AppData\Local\Microsoft\WindowsApps\winget.exe){
-    'Winget Already Installed'
-}  
-else{
-    # Installing winget from the Microsoft Store
-	Write-Host "Winget not found, installing it now."
-    $ResultText.text = "`r`n" +"`r`n" + "Installing Winget... Please Wait"
+# Check if WinGet is Installed, if Not Install From MS Store
+Write-Host "Checking Winget..."
+if (!(Test-Path ~\AppData\Local\Microsoft\WindowsApps\winget.exe)){  
+    Write-Host "Winget not Found, Installing Now."
 	Start-Process "ms-appinstaller:?source=https://aka.ms/getwinget"
 	$nid = (Get-Process AppInstaller).Id
 	Wait-Process -Id $nid
-	Write-Host Winget Installed
+	Write-Host "Winget Installed"
     $ResultText.text = "`r`n" +"`r`n" + "Winget Installed - Ready for Next Task"
 }
 
+# GUI Specs
 $Form                            = New-Object system.Windows.Forms.Form
 $Form.ClientSize                 = New-Object System.Drawing.Point(1050,1000)
 $Form.text                       = "Windows Toolbox By Chris Titus"
@@ -126,12 +117,12 @@ $powertoys.height                = 30
 $powertoys.location              = New-Object System.Drawing.Point(4,67)
 $powertoys.Font                  = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
-$winterminal                     = New-Object system.Windows.Forms.Button
-$winterminal.text                = "Windows Terminal"
-$winterminal.width               = 211
-$winterminal.height              = 30
-$winterminal.location            = New-Object System.Drawing.Point(3,32)
-$winterminal.Font                = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
+$batchinstall                     = New-Object system.Windows.Forms.Button
+$batchinstall.text                = "Batch Install"
+$batchinstall.width               = 211
+$batchinstall.height              = 30
+$batchinstall.location            = New-Object System.Drawing.Point(3,32)
+$batchinstall.Font                = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
 $vscode                          = New-Object system.Windows.Forms.Button
 $vscode.text                     = "VS Code"
@@ -612,12 +603,12 @@ $oldsoundpanel.height            = 30
 $oldsoundpanel.location          = New-Object System.Drawing.Point(4,163)
 $oldsoundpanel.Font              = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
-$Button1                         = New-Object system.Windows.Forms.Button
-$Button1.text                    = "Old System Panel"
-$Button1.width                   = 211
-$Button1.height                  = 30
-$Button1.location                = New-Object System.Drawing.Point(4,197)
-$Button1.Font                    = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
+$oldsystempanel                         = New-Object system.Windows.Forms.Button
+$oldsystempanel.text                    = "Old System Panel"
+$oldsystempanel.width                   = 211
+$oldsystempanel.height                  = 30
+$oldsystempanel.location                = New-Object System.Drawing.Point(4,197)
+$oldsystempanel.Font                    = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
 $NFS                             = New-Object system.Windows.Forms.Button
 $NFS.text                        = "Enable NFS"
@@ -627,10 +618,10 @@ $NFS.location                    = New-Object System.Drawing.Point(4,232)
 $NFS.Font                        = New-Object System.Drawing.Font('Microsoft Sans Serif',12)
 
 $Form.controls.AddRange(@($Panel1,$Panel2,$Label3,$Label15,$Panel4,$PictureBox1,$Label1,$Label4,$Panel3,$ResultText,$Label10,$Label11,$urlfixwinstartup,$urlremovevirus,$urlcreateiso))
-$Panel1.controls.AddRange(@($brave,$firefox,$7zip,$sharex,$adobereader,$notepad,$gchrome,$mpc,$vlc,$powertoys,$winterminal,$vscode,$Label2,$everythingsearch,$sumatrapdf,$vscodium,$imageglass,$gimp,$Label7,$Label8,$Label9,$advancedipscanner,$putty,$etcher,$translucenttb,$githubdesktop,$discord,$autohotkey))
+$Panel1.controls.AddRange(@($brave,$firefox,$7zip,$sharex,$adobereader,$notepad,$gchrome,$mpc,$vlc,$powertoys,$batchinstall,$vscode,$Label2,$everythingsearch,$sumatrapdf,$vscodium,$imageglass,$gimp,$Label7,$Label8,$Label9,$advancedipscanner,$putty,$etcher,$translucenttb,$githubdesktop,$discord,$autohotkey))
 $Panel2.controls.AddRange(@($essentialtweaks,$backgroundapps,$cortana,$actioncenter,$darkmode,$performancefx,$onedrive,$lightmode,$essentialundo,$EActionCenter,$ECortana,$RBackgroundApps,$HTrayIcons,$EClipboardHistory,$ELocation,$InstallOneDrive,$removebloat,$reinstallbloat,$WarningLabel,$Label5,$appearancefx,$STrayIcons,$EHibernation,$dualboottime))
 $Panel4.controls.AddRange(@($defaultwindowsupdate,$securitywindowsupdate,$Label16,$Label17,$Label18,$Label19))
-$Panel3.controls.AddRange(@($yourphonefix,$Label6,$windowsupdatefix,$ncpa,$oldcontrolpanel,$oldsoundpanel,$Button1,$NFS))
+$Panel3.controls.AddRange(@($yourphonefix,$Label6,$windowsupdatefix,$ncpa,$oldcontrolpanel,$oldsoundpanel,$oldsystempanel,$NFS))
 
 $brave.Add_Click({
     Write-Host "Installing Brave Browser"
@@ -746,12 +737,43 @@ $urlcreateiso.Add_Click({
     Start-Process "https://youtu.be/R6XPff38iSc"
 })
 
-$winterminal.Add_Click({
-    Write-Host "Installing New Windows Terminal"
-    $ResultText.text = "`r`n" +"`r`n" + "Installing New Windows Terminal... Please Wait" 
-    winget install -e Microsoft.WindowsTerminal | Out-Host
-    if($?) { Write-Host "Installed New Windows Terminal" }
-    $ResultText.text = "`r`n" + "Finished Installing New Windows Terminal" + "`r`n" + "`r`n" + "Ready for Next Task"
+$batchinstall.Add_Click({
+    $applications = @(
+        "## Utilities"
+        "Windows Terminal"
+        "PowerToys (Preview)"
+        "7-Zip"
+        "AutoHotkey"
+        "Discord"
+        "GitHub Desktop"
+        "TranslucentTB"
+        "balenaEtcher"
+        "PuTTY"
+        "WinSCP"
+        "Advanced IP Scanner"
+        "Everything"
+        "## Web Browsers"
+        "Brave"
+        "Mozilla Firefox"
+        "Google Chrome"
+        "## Video & Image Tools"
+        "ShareX"
+        "ImageGlass"
+        "GIMP"
+        "VLC media player"
+        "MPC-HC"
+        "## Document Tools"
+        "VSCodium"
+        "Microsoft Visual Studio Code"
+        "Notepad++"
+        "Adobe Acrobat Reader DC"
+    )
+    $install = $applications | Out-GridView -Title "Select Application(s) to Install" -OutputMode Multiple
+    foreach ($application in $install){
+    	$ResultText.text = "`r`n" +"`r`n" + "Installing $application"
+    	winget install -s winget -e "$application" --accept-source-agreements | Out-Host
+	}
+    $ResultText.text = "`r`n" + "Finished Installing Application(s)" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
 
 $powertoys.Add_Click({
@@ -1247,94 +1269,9 @@ $essentialundo.Add_Click({
     $ResultText.text = "`r`n" +"`r`n" + "Essential Undo Completed - Ready for next task"
 })
 
-$windowssearch.Add_Click({
-    Write-Host "Disabling Bing Search in Start Menu..."
-    $ResultText.text = "`r`n" +"`r`n" + "Disabling Search, Cortana, Start menu search... Please Wait"
-    Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Search" -Name "BingSearchEnabled" -Type DWord -Value 0
-    <#
-    Write-Host "Disabling Cortana"
-    Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Search" -Name "CortanaConsent" -Type DWord -Value 0
-    If (!(Test-Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Search")) {
-        New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Search" -Force | Out-Null
-    }
-    #>
-    Write-Host "Hiding Search Box / Button..."
-    Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Search" -Name "SearchboxTaskbarMode" -Type DWord -Value 0
-
-    Write-Host "Removing Start Menu Tiles"
-
-    Set-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -Value '<LayoutModificationTemplate xmlns:defaultlayout="http://schemas.microsoft.com/Start/2014/FullDefaultLayout" xmlns:start="http://schemas.microsoft.com/Start/2014/StartLayout" Version="1" xmlns="http://schemas.microsoft.com/Start/2014/LayoutModification">'
-    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '  <LayoutOptions StartTileGroupCellWidth="6" />'
-    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '  <DefaultLayoutOverride>'
-    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '    <StartLayoutCollection>'
-    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '      <defaultlayout:StartLayout GroupCellWidth="6" />'
-    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '    </StartLayoutCollection>'
-    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '  </DefaultLayoutOverride>'
-    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '    <CustomTaskbarLayoutCollection>'
-    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '      <defaultlayout:TaskbarLayout>'
-    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '        <taskbar:TaskbarPinList>'
-    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '          <taskbar:UWA AppUserModelID="Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge" />'
-    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '          <taskbar:DesktopApp DesktopApplicationLinkPath="%APPDATA%\Microsoft\Windows\Start Menu\Programs\System Tools\File Explorer.lnk" />'
-    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '        </taskbar:TaskbarPinList>'
-    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '      </defaultlayout:TaskbarLayout>'
-    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '    </CustomTaskbarLayoutCollection>'
-    Add-Content -Path 'C:\Users\Default\AppData\Local\Microsoft\Windows\Shell\DefaultLayouts.xml' -value '</LayoutModificationTemplate>'
-
-    $START_MENU_LAYOUT = @"
-    <LayoutModificationTemplate xmlns:defaultlayout="http://schemas.microsoft.com/Start/2014/FullDefaultLayout" xmlns:start="http://schemas.microsoft.com/Start/2014/StartLayout" Version="1" xmlns:taskbar="http://schemas.microsoft.com/Start/2014/TaskbarLayout" xmlns="http://schemas.microsoft.com/Start/2014/LayoutModification">
-        <LayoutOptions StartTileGroupCellWidth="6" />
-        <DefaultLayoutOverride>
-            <StartLayoutCollection>
-                <defaultlayout:StartLayout GroupCellWidth="6" />
-            </StartLayoutCollection>
-        </DefaultLayoutOverride>
-    </LayoutModificationTemplate>
-"@
-
-    $layoutFile="C:\Windows\StartMenuLayout.xml"
-
-    #Delete layout file if it already exists
-    If(Test-Path $layoutFile)
-    {
-        Remove-Item $layoutFile
-    }
-
-    #Creates the blank layout file
-    $START_MENU_LAYOUT | Out-File $layoutFile -Encoding ASCII
-
-    $regAliases = @("HKLM", "HKCU")
-
-    #Assign the start layout and force it to apply with "LockedStartLayout" at both the machine and user level
-    foreach ($regAlias in $regAliases){
-        $basePath = $regAlias + ":\SOFTWARE\Policies\Microsoft\Windows"
-        $keyPath = $basePath + "\Explorer"
-        IF(!(Test-Path -Path $keyPath)) {
-            New-Item -Path $basePath -Name "Explorer"
-        }
-        Set-ItemProperty -Path $keyPath -Name "LockedStartLayout" -Value 1
-        Set-ItemProperty -Path $keyPath -Name "StartLayoutFile" -Value $layoutFile
-    }
-
-    #Restart Explorer, open the start menu (necessary to load the new layout), and give it a few seconds to process
-    Stop-Process -name explorer
-    Start-Sleep -s 5
-    $wshell = New-Object -ComObject wscript.shell; $wshell.SendKeys('^{ESCAPE}')
-    Start-Sleep -s 5
-
-    #Enable the ability to pin items again by disabling "LockedStartLayout"
-    foreach ($regAlias in $regAliases){
-        $basePath = $regAlias + ":\SOFTWARE\Policies\Microsoft\Windows"
-        $keyPath = $basePath + "\Explorer"
-        Set-ItemProperty -Path $keyPath -Name "LockedStartLayout" -Value 0
-
-    Write-Host "Search and Start Menu Tweaks Complete"
-    $ResultText.text = "`r`n" +"`r`n" + "Search and Start Menu Tweaks Complete"
-    }
-})
-
 $backgroundapps.Add_Click({
     Write-Host "Disabling Background application access..."
-    Get-ChildItem -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" -Exclude "Microsoft.Windows.Cortana*" | ForEach {
+    Get-ChildItem -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" -Exclude "Microsoft.Windows.Cortana*" | ForEach-Object {
         Set-ItemProperty -Path $_.PsPath -Name "Disabled" -Type DWord -Value 1
         Set-ItemProperty -Path $_.PsPath -Name "DisabledByUser" -Type DWord -Value 1
     }
@@ -1687,7 +1624,7 @@ $ELocation.Add_Click({
 
 $RBackgroundApps.Add_Click({
 	Write-Host "Allowing Background Apps..."
-	Get-ChildItem -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" -Exclude "Microsoft.Windows.Cortana*" | ForEach {
+	Get-ChildItem -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" -Exclude "Microsoft.Windows.Cortana*" | ForEach-Object {
 		Remove-ItemProperty -Path $_.PsPath -Name "Disabled" -ErrorAction SilentlyContinue
 		Remove-ItemProperty -Path $_.PsPath -Name "DisabledByUser" -ErrorAction SilentlyContinue
 	}
@@ -1710,17 +1647,6 @@ $InstallOneDrive.Add_Click({
     $ResultText.text = "`r`n" +"`r`n" + "Finished Reinstalling OneDrive"
 })
 
-$DisableNumLock.Add_Click({
-    Write-Host "Disable NumLock after startup..."
-    Set-ItemProperty -Path "HKU:\.DEFAULT\Control Panel\Keyboard" -Name "InitialKeyboardIndicators" -Type DWord -Value 0
-    Add-Type -AssemblyName System.Windows.Forms
-    If (([System.Windows.Forms.Control]::IsKeyLocked('NumLock'))) {
-        $wsh = New-Object -ComObject WScript.Shell
-        $wsh.SendKeys('{NUMLOCK}')
-    }
-    $ResultText.text = "`r`n" +"`r`n" + "NUMLOCK Disabled"
-})
-
 $yourphonefix.Add_Click({
     Write-Host "Reinstalling Your Phone App"
     Add-AppxPackage -DisableDevelopmentMode -Register "$($(Get-AppXPackage -AllUsers "Microsoft.YourPhone").InstallLocation)\AppXManifest.xml"
@@ -1729,7 +1655,7 @@ $yourphonefix.Add_Click({
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" -Name "EnableCdp" -Type DWord -Value 1
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Messaging" -Name "AllowMessageSync" -Type DWord -Value 1
     Write-Host "Allowing Background Apps..."
-	Get-ChildItem -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" -Exclude "Microsoft.Windows.Cortana*" | ForEach {
+	Get-ChildItem -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" -Exclude "Microsoft.Windows.Cortana*" | ForEach-Object {
 		Remove-ItemProperty -Path $_.PsPath -Name "Disabled" -ErrorAction SilentlyContinue
 		Remove-ItemProperty -Path $_.PsPath -Name "DisabledByUser" -ErrorAction SilentlyContinue
 	}
@@ -1761,6 +1687,7 @@ $NFS.Add_Click({
     Write-Host "NFS is now setup for user based NFS mounts"
     $ResultText.text = "`r`n" +"`r`n" + "NFS is now setup for user based NFS mounts"
 })
+
 $windowsupdatefix.Add_Click({
     Write-Host "1. Stopping Windows Update Services..." 
     Stop-Service -Name BITS 


### PR DESCRIPTION
- Added batch install for winGet apps
- Simplified & slimmed WinGet check
- Replaced "ms-appinstaller" method of installing WinGet with new BitsTransfer method because of a [security vulnerability](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-43890)