### PR TITLE
Fixed dead package name for adobe reader installer

### DIFF
--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -681,7 +681,7 @@ $discord.Add_Click({
 $adobereader.Add_Click({
     Write-Host "Installing Adobe Reader DC"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Adobe Reader DC... Please Wait" 
-    winget install -e Adobe.AdobeAcrobatReaderDC | Out-Host
+    winget install -e --id Adobe.Acrobat.Reader.64-bit | Out-Host
     if($?) { Write-Host "Installed Adobe Reader DC" }
     $ResultText.text = "`r`n" + "Finished Installing Adobe Reader DC" + "`r`n" + "`r`n" + "Ready for Next Task"
 })


### PR DESCRIPTION
I noticed while using the script on a new Windows install that winget wasn't finding the adobe reader package, so I quicly fixed it, as it seems like the package name on winget has changed.