### PR TITLE
Fix Action Center/Quick Settings Bug in Windows 11

### DIFF
--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -1594,14 +1594,19 @@ $securitywindowsupdate.Add_Click({
 })
 
 $actioncenter.Add_Click({
-    Write-Host "Disabling Action Center..."
-    If (!(Test-Path "HKCU:\SOFTWARE\Policies\Microsoft\Windows\Explorer")) {
-        New-Item -Path "HKCU:\SOFTWARE\Policies\Microsoft\Windows\Explorer" | Out-Null
+    if((Get-ComputerInfo).OSName.Substring(0,20) -eq "Microsoft Windows 11"){
+        Write-Host "This breaks Quick Settings in Windows 11 and is therefore not executed."
+        $ResultText.text = "`r`n" +"`r`n" + "This breaks Quick Settings in Windows 11 and is therefore not executed."
+    }else{
+        Write-Host "Disabling Action Center..."
+        If (!(Test-Path "HKCU:\SOFTWARE\Policies\Microsoft\Windows\Explorer")) {
+            New-Item -Path "HKCU:\SOFTWARE\Policies\Microsoft\Windows\Explorer" | Out-Null
+        }
+        Set-ItemProperty -Path "HKCU:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "DisableNotificationCenter" -Type DWord -Value 1
+        Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\PushNotifications" -Name "ToastEnabled" -Type DWord -Value 0
+        Write-Host "Disabled Action Center"
+        $ResultText.text = "`r`n" +"`r`n" + "Disabled Action Center"
     }
-    Set-ItemProperty -Path "HKCU:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "DisableNotificationCenter" -Type DWord -Value 1
-    Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\PushNotifications" -Name "ToastEnabled" -Type DWord -Value 0
-    Write-Host "Disabled Action Center"
-    $ResultText.text = "`r`n" +"`r`n" + "Disabled Action Center"
 })
 
 $performancefx.Add_Click({


### PR DESCRIPTION
win10debloat.ps1:
 - Closes #237, If action center is 'disabled' in Windows 11, Quick Settings is broken. This is fixed by adding detection of the Windows version before running $actioncenter, meaning action center won't be 'disabled' if the script is run in Windows 11.