### PR TITLE
Fix Bug

### DIFF
--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -669,7 +669,7 @@ $Panel3.controls.AddRange(@($yourphonefix,$ncpa,$oldcontrolpanel,$oldsoundpanel,
 $brave.Add_Click({
     Write-Host "Installing Brave Browser"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Brave... Please Wait" 
-    winget install -e BraveSoftware.BraveBrowser | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent BraveSoftware.BraveBrowser | Out-Host
     if($?) { Write-Host "Installed Brave Browser" }
     $ResultText.text = "`r`n" + "Finished Installing Brave" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -677,7 +677,7 @@ $brave.Add_Click({
 $firefox.Add_Click({
     Write-Host "Installing Firefox"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Firefox... Please Wait" 
-    winget install -e Mozilla.Firefox | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent Mozilla.Firefox | Out-Host
     if($?) { Write-Host "Installed Firefox" }
     $ResultText.text = "`r`n" + "Finished Installing Firefox" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -685,7 +685,7 @@ $firefox.Add_Click({
 $gchrome.Add_Click({
     Write-Host "Installing Google Chrome"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Google Chrome... Please Wait" 
-    winget install -e Google.Chrome | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent Google.Chrome | Out-Host
     if($?) { Write-Host "Installed Google Chrome" }
     $ResultText.text = "`r`n" + "Finished Installing Google Chrome" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -693,21 +693,21 @@ $gchrome.Add_Click({
 $autohotkey.Add_Click({
     Write-Host "Installing AutoHotkey"
     $ResultText.text = "`r`n" +"`r`n" + "Installing AutoHotkey... Please Wait" 
-    winget install -e Lexikos.AutoHotkey | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent Lexikos.AutoHotkey | Out-Host
     if($?) { Write-Host "Installed AutoHotkey" }
     $ResultText.text = "`r`n" + "Finished Installing Autohotkey" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
 $imageglass.Add_Click({
     Write-Host "Installing Image Glass (Image Viewer)"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Image Glass... Please Wait" 
-    winget install -e DuongDieuPhap.ImageGlass | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent DuongDieuPhap.ImageGlass | Out-Host
     if($?) { Write-Host "Installed Image Glass (Image Viewer)" }
     $ResultText.text = "`r`n" + "Finished Installing Image Glass" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
 $discord.Add_Click({
     Write-Host "Installing Discord"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Discord... Please Wait" 
-    winget install -e Discord.Discord | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent Discord.Discord | Out-Host
     if($?) { Write-Host "Installed Discord" }
     $ResultText.text = "`r`n" + "Finished Installing Discord" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -715,7 +715,7 @@ $discord.Add_Click({
 $adobereader.Add_Click({
     Write-Host "Installing Adobe Reader DC"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Adobe Reader DC... Please Wait" 
-    winget install -e --id Adobe.Acrobat.Reader.64-bit | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent --id Adobe.Acrobat.Reader.64-bit | Out-Host
     if($?) { Write-Host "Installed Adobe Reader DC" }
     $ResultText.text = "`r`n" + "Finished Installing Adobe Reader DC" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -723,7 +723,7 @@ $adobereader.Add_Click({
 $notepad.Add_Click({
     Write-Host "Installing Notepad++"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Notepad++... Please Wait" 
-    winget install -e Notepad++.Notepad++ | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent Notepad++.Notepad++ | Out-Host
     if($?) { Write-Host "Installed Notepad++" }
     $ResultText.text = "`r`n" + "Finished Installing NotePad++" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -731,7 +731,7 @@ $notepad.Add_Click({
 $vlc.Add_Click({
     Write-Host "Installing VLC Media Player"
     $ResultText.text = "`r`n" +"`r`n" + "Installing VLC Media Player... Please Wait" 
-    winget install -e VideoLAN.VLC | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent VideoLAN.VLC | Out-Host
     if($?) { Write-Host "Installed VLC Media Player" }
     $ResultText.text = "`r`n" + "Finished Installing VLC Media Player" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -739,7 +739,7 @@ $vlc.Add_Click({
 $mpc.Add_Click({
     Write-Host "Installing Media Player Classic"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Media Player Classic... Please Wait" 
-    winget install -e clsid2.mpc-hc | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent clsid2.mpc-hc | Out-Host
     if($?) { Write-Host "Installed Media Player Classic" }
     $ResultText.text = "`r`n" + "Finished Installing Media Player Classic" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -747,7 +747,7 @@ $mpc.Add_Click({
 $7zip.Add_Click({
     Write-Host "Installing 7-Zip Compression Tool"
     $ResultText.text = "`r`n" +"`r`n" + "Installing 7-Zip Compression Tool... Please Wait" 
-    winget install -e 7zip.7zip | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent 7zip.7zip | Out-Host
     if($?) { Write-Host "Installed 7-Zip Compression Tool" }
     $ResultText.text = "`r`n" + "Finished Installing 7-Zip Compression Tool" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -755,7 +755,7 @@ $7zip.Add_Click({
 $vscode.Add_Click({
     Write-Host "Installing Visual Studio Code"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Visual Studio Code... Please Wait" 
-    winget install -e Microsoft.VisualStudioCode --source winget | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent Microsoft.VisualStudioCode --source winget | Out-Host
     if($?) { Write-Host "Installed Visual Studio Code" }
     $ResultText.text = "`r`n" + "Finished Installing Visual Studio Code" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -763,7 +763,7 @@ $vscode.Add_Click({
 $vscodium.Add_Click({
     Write-Host "Installing VS Codium"
     $ResultText.text = "`r`n" +"`r`n" + "Installing VS Codium... Please Wait" 
-    winget install -e VSCodium.VSCodium | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent VSCodium.VSCodium | Out-Host
     if($?) { Write-Host "Installed VS Codium" }
     $ResultText.text = "`r`n" + "Finished Installing VS Codium" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -783,7 +783,7 @@ $urlcreateiso.Add_Click({
 $winterminal.Add_Click({
     Write-Host "Installing New Windows Terminal"
     $ResultText.text = "`r`n" +"`r`n" + "Installing New Windows Terminal... Please Wait" 
-    winget install -e Microsoft.WindowsTerminal | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent Microsoft.WindowsTerminal | Out-Host
     if($?) { Write-Host "Installed New Windows Terminal" }
     $ResultText.text = "`r`n" + "Finished Installing New Windows Terminal" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -791,7 +791,7 @@ $winterminal.Add_Click({
 $powertoys.Add_Click({
     Write-Host "Installing Microsoft PowerToys"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Microsoft PowerToys... Please Wait" 
-    winget install -e Microsoft.PowerToys | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent Microsoft.PowerToys | Out-Host
     if($?) { Write-Host "Installed Microsoft PowerToys" }
     $ResultText.text = "`r`n" + "Finished Installing Microsoft PowerToys" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -799,7 +799,7 @@ $powertoys.Add_Click({
 $everythingsearch.Add_Click({
     Write-Host "Installing Voidtools Everything Search"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Voidtools Everything Search... Please Wait" 
-    winget install -e voidtools.Everything --source winget | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent voidtools.Everything --source winget | Out-Host
     if($?) { Write-Host "Installed Everything Search" }
     $ResultText.text = "`r`n" + "Finished Installing Voidtools Everything Search" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -807,7 +807,7 @@ $everythingsearch.Add_Click({
 $sumatrapdf.Add_Click({
     Write-Host "Installing Sumatra PDF"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Sumatra PDF... Please Wait" 
-    winget install -e SumatraPDF.SumatraPDF | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent SumatraPDF.SumatraPDF | Out-Host
     if($?) { Write-Host "Installed Sumatra PDF" }
     $ResultText.text = "`r`n" + "Finished Installing Sumatra PDF" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -815,8 +815,8 @@ $sumatrapdf.Add_Click({
 $githubdesktop.Add_Click({
     Write-Host "Installing Git and GitHub Desktop"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Git and GitHub Desktop... Please Wait" 
-    winget install -e Git.Git | Out-Host
-    winget install -e GitHub.GitHubDesktop | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent Git.Git | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent GitHub.GitHubDesktop | Out-Host
     Write-Host "Installed Git and Github Desktop"
     $ResultText.text = "`r`n" + "Finished Installing Git and GitHub Desktop" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -824,7 +824,7 @@ $githubdesktop.Add_Click({
 $translucenttb.Add_Click({
     Write-Host "Installing Translucent Taskbar"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Translucent Taskbar... Please Wait" 
-    winget install -e TranslucentTB.TranslucentTB | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent TranslucentTB.TranslucentTB | Out-Host
     Write-Host "Installed Translucent Taskbar"
     $ResultText.text = "`r`n" + "Finished Installing Translucent Taskbar" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -832,7 +832,7 @@ $translucenttb.Add_Click({
 $etcher.Add_Click({
     Write-Host "Installing Etcher USB Imager"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Etcher USB Imager... Please Wait" 
-    winget install -e Balena.Etcher | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent Balena.Etcher | Out-Host
     Write-Host "Installed Etcher USB Imager"
     $ResultText.text = "`r`n" + "Finished Installing Etcher USB Imager" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -840,8 +840,8 @@ $etcher.Add_Click({
 $putty.Add_Click({
     Write-Host "Installing PuTTY & WinSCP"
     $ResultText.text = "`r`n" +"`r`n" + "Installing PuTTY & WinSCP... Please Wait" 
-    winget install -e PuTTY.PuTTY | Out-Host
-    winget install -e WinSCP.WinSCP | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent PuTTY.PuTTY | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent WinSCP.WinSCP | Out-Host
     Write-Host "Installed PuTTY & WinSCP"
     $ResultText.text = "`r`n" + "Finished Installing PuTTY & WinSCP" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -849,7 +849,7 @@ $putty.Add_Click({
 $advancedipscanner.Add_Click({
     Write-Host "Installing Advanced IP Scanner"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Advanced IP Scanner... Please Wait" 
-    winget install -e Famatech.AdvancedIPScanner | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent Famatech.AdvancedIPScanner | Out-Host
     Write-Host "Installed Advanced IP Scanner"
     $ResultText.text = "`r`n" + "Finished Installing Advanced IP Scanner" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -857,7 +857,7 @@ $advancedipscanner.Add_Click({
 $sharex.Add_Click({
     Write-Host "Installing ShareX Screenshot Tool"
     $ResultText.text = "`r`n" +"`r`n" + "Installing ShareX Screenshot Tool... Please Wait" 
-    winget install -e ShareX.ShareX | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent ShareX.ShareX | Out-Host
     Write-Host "Installed ShareX Screenshot Tool"
     $ResultText.text = "`r`n" + "Finished Installing ShareX Screenshot Tool" + "`r`n" + "`r`n" + "Ready for Next Task"
 })
@@ -865,7 +865,7 @@ $sharex.Add_Click({
 $gimp.Add_Click({
     Write-Host "Installing Gimp Image Editor"
     $ResultText.text = "`r`n" +"`r`n" + "Installing Gimp Image Editor... Please Wait" 
-    winget install -e GIMP.GIMP | Out-Host
+    winget install -e --accept-source-agreements --accept-package-agreements --silent GIMP.GIMP | Out-Host
     Write-Host "Installed Gimp Image Editor"
     $ResultText.text = "`r`n" + "Finished Installing Gimp Image Editor" + "`r`n" + "`r`n" + "Ready for Next Task"
 })


### PR DESCRIPTION
win10debloat.ps1:
 - Closes #283, When running winget for the first time, many programs would require manual interaction to accept terms and conditions and the license agreement. This fixes that by adding the flags --accept-source-agreements --accept-package-agreements --silent to every winget install to eliminate the need for manual interactions in the case there is one.
 
 Much of this was previously in my pull request https://github.com/ChrisTitusTech/win10script/pull/285 but there were issues with the diff creating confusion that caused it to be closed. So I'm redoing everything and putting them all into separate pull requests to increase clarity on exactly what has changed.