### PR TITLE
Fix Xbox Live Bug

### DIFF
--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -1104,9 +1104,9 @@ Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies
     "WMPNetworkSvc"                                # Windows Media Player Network Sharing Service
     #"wscsvc"                                       # Windows Security Center Service
     "WSearch"                                      # Windows Search
-    #"XblAuthManager"                              # Xbox Live Auth Manager (Disabling Breaks Xbox Live Games)
-    #"XblGameSave"                                 # Xbox Live Game Save Service (Disabling Breaks Xbox Live Games)
-    #"XboxNetApiSvc"                               # Xbox Live Networking Service (Disabling Breaks Xbox Live Games)
+    "XblAuthManager"                               # Xbox Live Auth Manager (Disabling Breaks Xbox Live Games)
+    "XblGameSave"                                  # Xbox Live Game Save Service (Disabling Breaks Xbox Live Games)
+    "XboxNetApiSvc"                                # Xbox Live Networking Service (Disabling Breaks Xbox Live Games)
     "XboxGipSvc"                                   #Disables Xbox Accessory Management Service
     "ndu"                                          # Windows Network Data Usage Monitor
     "WerSvc"                                       #disables windows error reporting

--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -1104,9 +1104,9 @@ Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies
     "WMPNetworkSvc"                                # Windows Media Player Network Sharing Service
     #"wscsvc"                                       # Windows Security Center Service
     "WSearch"                                      # Windows Search
-    "XblAuthManager"                               # Xbox Live Auth Manager
-    "XblGameSave"                                  # Xbox Live Game Save Service
-    "XboxNetApiSvc"                                # Xbox Live Networking Service
+    #"XblAuthManager"                              # Xbox Live Auth Manager (Disabling Breaks Xbox Live Games)
+    #"XblGameSave"                                 # Xbox Live Game Save Service (Disabling Breaks Xbox Live Games)
+    #"XboxNetApiSvc"                               # Xbox Live Networking Service (Disabling Breaks Xbox Live Games)
     "XboxGipSvc"                                   #Disables Xbox Accessory Management Service
     "ndu"                                          # Windows Network Data Usage Monitor
     "WerSvc"                                       #disables windows error reporting
@@ -1482,7 +1482,7 @@ $Bloatware = @(
     "Microsoft.XboxGameCallableUI"
     "Microsoft.XboxSpeechToTextOverlay"
     "Microsoft.MixedReality.Portal"
-    "Microsoft.XboxIdentityProvider"
+    #"Microsoft.XboxIdentityProvider" # Breaks Xbox Live in games like Minecraft UWP
     "Microsoft.ZuneMusic"
     "Microsoft.ZuneVideo"
     "Microsoft.YourPhone"


### PR DESCRIPTION
 - Removing Xbox Identity Provider breaks Xbox Live games like Minecraft UWP
   - Fixed by commenting out the App in $Bloatware