### PR TITLE
Additions from #335

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin/x64/ctt-toolbox.zip
 win10debloat.ps1.psbuild
 ctt-toolbox.exe
 winget-latest.appxbundle
+.vs

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ defltbase.sdb
 bin/x64/ctt-toolbox.exe
 bin/x64/ctt-toolbox.zip
 win10debloat.ps1.psbuild
-.vs

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ defltbase.sdb
 bin/x64/ctt-toolbox.exe
 bin/x64/ctt-toolbox.zip
 win10debloat.ps1.psbuild
+.vs

--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -1085,6 +1085,14 @@ Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies
     Write-Host "Showing known file extensions..."
     Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "HideFileExt" -Type DWord -Value 0
 
+    if(!(((Get-ComputerInfo).WindowsEditionId).IndexOf('Core') -eq -1) -or !(((Get-ComputerInfo).WindowsEditionId).IndexOf('Home') -eq -1)){ # Not sure if home edition is Core or Home
+        Write-Host "Enabling gpedit.msc..."
+        Get-ChildItem @(
+            "C:\Windows\servicing\Packages\Microsoft-Windows-GroupPolicy-ClientTools-Package*.mum",
+            "C:\Windows\servicing\Packages\Microsoft-Windows-GroupPolicy-ClientExtensions-Package*.mum"
+        ) | ForEach-Object { dism.exe /online /norestart /add-package:"$_" }
+    }
+
     # Service tweaks to Manual 
 
     $services = @(

--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -1085,6 +1085,10 @@ Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies
     Write-Host "Showing known file extensions..."
     Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "HideFileExt" -Type DWord -Value 0
 
+    if(($(Get-WMIObject -class Win32_ComputerSystem | select username).username).IndexOf('Administrator') -eq -1){
+        net user administrator /active:no
+    }
+
     if(!(((Get-ComputerInfo).WindowsEditionId).IndexOf('Core') -eq -1) -or !(((Get-ComputerInfo).WindowsEditionId).IndexOf('Home') -eq -1)){ # Not sure if home edition is Core or Home
         Write-Host "Enabling gpedit.msc..."
         Get-ChildItem @(


### PR DESCRIPTION
Both of these were recommended in #335
 - Adds check to see if the currently logged in account is the built-in admin account
   - if not, disables the built-in admin account
 - Adds check on if the currently installed Windows version is 'Home'
   - if so, it uses DISM to install gpedit.msc