### PR TITLE
Updated Winget Install

### DIFF
--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -14,7 +14,7 @@ If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
 Write-Host "Checking for Winget..."
 
 # If Winget isn't Installed, Open MS Store Window to Install
-if (!Get-AppPackage -name 'Microsoft.DesktopAppInstaller') {
+if (!(Get-AppPackage -name 'Microsoft.DesktopAppInstaller')) {
     Write-Host "Winget not Found, Installing Now"
     Start-Process "ms-windows-store://pdp/?ProductId=9NBLGGH4NNS1"
     $nid = (Get-Process AppInstaller).Id; Wait-Process -Id $nid

--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -11,21 +11,14 @@ If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
 }
 
 # GUI Specs
-Write-Host "Checking winget..."
+Write-Host "Checking for Winget..."
 
-# Check if winget is installed
-if (Test-Path ~\AppData\Local\Microsoft\WindowsApps\winget.exe){
-    'Winget Already Installed'
-}  
-else{
-    # Installing winget from the Microsoft Store
-	Write-Host "Winget not found, installing it now."
-    $ResultText.text = "`r`n" +"`r`n" + "Installing Winget... Please Wait"
-	Start-Process "ms-appinstaller:?source=https://aka.ms/getwinget"
-	$nid = (Get-Process AppInstaller).Id
-	Wait-Process -Id $nid
-	Write-Host Winget Installed
-    $ResultText.text = "`r`n" +"`r`n" + "Winget Installed - Ready for Next Task"
+# If Winget isn't Installed, Open MS Store Window to Install
+if (!Get-AppPackage -name 'Microsoft.DesktopAppInstaller') {
+    Write-Host "Winget not Found, Installing Now"
+    Start-Process "ms-windows-store://pdp/?ProductId=9NBLGGH4NNS1"
+    $nid = (Get-Process AppInstaller).Id; Wait-Process -Id $nid
+    Write-Host "Winget Successfully Installed"
 }
 
 $Form                            = New-Object system.Windows.Forms.Form

--- a/win10debloat.ps1
+++ b/win10debloat.ps1
@@ -13,11 +13,11 @@ If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
 # GUI Specs
 Write-Host "Checking for Winget..."
 
-# If Winget isn't Installed, Open MS Store Window to Install
+# If Winget isn't Installed, Open App Installer Store Page to Install
 if (!(Get-AppPackage -name 'Microsoft.DesktopAppInstaller')) {
     Write-Host "Winget not Found, Installing Now"
     Start-Process "ms-windows-store://pdp/?ProductId=9NBLGGH4NNS1"
-    $nid = (Get-Process AppInstaller).Id; Wait-Process -Id $nid
+    $nid = (Get-Process WinStore.App).Id; Wait-Process -Id $nid
     Write-Host "Winget Successfully Installed"
 }
 


### PR DESCRIPTION
- Removed $ResultText.text messages because Form isn't created yet which throws errors
- Only runs if Winget isn't found
- Swapped `ms-appinstaller` with `ms-windows-store` method because ms-appinstaller is disabled due to CVE-2021-43890
- Swapped Test-Path with a Get-AppPackage based method because its more reliable