### PR TITLE
Skip extracting icons

### DIFF
--- a/Individual Scripts/spotlightimageextractor.cmd
+++ b/Individual Scripts/spotlightimageextractor.cmd
@@ -4,7 +4,7 @@ echo ---------------------------------------------------------------------------
 echo THIS SCRIPT WILL EXTRACT WINDOWS SPOTLIGHT IMAGES
 echo YOU MIGHT ENCOUNTER AN ERROR IF YOU HAVE NOT ENABLED WINDOWS SPOTLIGHT FOR YOUR LOCK SCREEN
 echo -----------------------------------------------------------------------------------------------
- 
+
 echo Script created by AaravHattangadi
 
 timeout 3 > nul
@@ -18,12 +18,11 @@ if not %var%== Y exit
 set /p optdir=Enter that path to your output directory here:
 
 cd /d %userprofile%\AppData\Local\Packages\Microsoft.Windows.ContentDeliveryManager_cw5n1h2txyewy\LocalState\Assets
-xcopy /s * %optdir%
+robocopy . %optdir% /s /xf /min:200000
 cd %optdir%
 ren *.* *.jpg
 
 echo The process has completed.
-echo There will be some icons copied as well. They are stored in the same folder as the spotlight images and this is a limitation of this script.
 
 echo This script will automatically close now.
 timeout 5


### PR DESCRIPTION
Added a filter option to exclude files under 200KB in size, allowing the script to extract only the images, and not the icons.